### PR TITLE
fix: replace connect url with gh page

### DIFF
--- a/.ssdb_config.ini.template
+++ b/.ssdb_config.ini.template
@@ -34,9 +34,9 @@ max_unresponsive_time=30
 upper_format={players}/{max_players} | {name}
 ; Change the lower format style by adding or removing comment markers for your desired format.
 ; SteamConnect.Site safely uses the Steam protocol to connect users to the server.
-; Source code repo can be found at: https://github.com/dangreene0/steamconnect
+; Source code repo can be found at: https://github.com/sour-dani/steamconnect
 lower_format=Map: {map} | Connect: `connect {address}`
-;lower_format=Map: {map} | Connect: [{address}](https://steamconnect.site/?{address})
+;lower_format=Map: {map} | Connect: [{address}](https://sour-dani.github.io/steamconnect/?{address})
 ; Set the logging level. Follows standard logging library levels. Defaults to warning.
 ; debug <- info <- warning <- error <- critical
 logging=warning


### PR DESCRIPTION
`steamconnect.site` is no longer in use and has been retired in favor of using a GitHub page link.